### PR TITLE
Corrects typo from mapDispachToProps to  mapDispatchToProps

### DIFF
--- a/13/components/App.js
+++ b/13/components/App.js
@@ -10,10 +10,10 @@ function mapStateToProps(state) {
   }
 }
 
-function mapDispachToProps(dispatch) {
+function mapDispatchToProps(dispatch) {
   return bindActionCreators(actionCreators, dispatch);
 }
 
-const App = connect(mapStateToProps, mapDispachToProps)(Main);
+const App = connect(mapStateToProps, mapDispatchToProps)(Main);
 
 export default App;

--- a/14/components/App.js
+++ b/14/components/App.js
@@ -10,10 +10,10 @@ function mapStateToProps(state) {
   }
 }
 
-function mapDispachToProps(dispatch) {
+function mapDispatchToProps(dispatch) {
   return bindActionCreators(actionCreators, dispatch);
 }
 
-const App = connect(mapStateToProps, mapDispachToProps)(Main);
+const App = connect(mapStateToProps, mapDispatchToProps)(Main);
 
 export default App;

--- a/15/components/App.js
+++ b/15/components/App.js
@@ -10,10 +10,10 @@ function mapStateToProps(state) {
   }
 }
 
-function mapDispachToProps(dispatch) {
+function mapDispatchToProps(dispatch) {
   return bindActionCreators(actionCreators, dispatch);
 }
 
-const App = connect(mapStateToProps, mapDispachToProps)(Main);
+const App = connect(mapStateToProps, mapDispatchToProps)(Main);
 
 export default App;

--- a/16/components/App.js
+++ b/16/components/App.js
@@ -10,10 +10,10 @@ function mapStateToProps(state) {
   }
 }
 
-function mapDispachToProps(dispatch) {
+function mapDispatchToProps(dispatch) {
   return bindActionCreators(actionCreators, dispatch);
 }
 
-const App = connect(mapStateToProps, mapDispachToProps)(Main);
+const App = connect(mapStateToProps, mapDispatchToProps)(Main);
 
 export default App;

--- a/17/components/App.js
+++ b/17/components/App.js
@@ -10,10 +10,10 @@ function mapStateToProps(state) {
   }
 }
 
-function mapDispachToProps(dispatch) {
+function mapDispatchToProps(dispatch) {
   return bindActionCreators(actionCreators, dispatch);
 }
 
-const App = connect(mapStateToProps, mapDispachToProps)(Main);
+const App = connect(mapStateToProps, mapDispatchToProps)(Main);
 
 export default App;

--- a/18/components/App.js
+++ b/18/components/App.js
@@ -10,10 +10,10 @@ function mapStateToProps(state) {
   }
 }
 
-function mapDispachToProps(dispatch) {
+function mapDispatchToProps(dispatch) {
   return bindActionCreators(actionCreators, dispatch);
 }
 
-const App = connect(mapStateToProps, mapDispachToProps)(Main);
+const App = connect(mapStateToProps, mapDispatchToProps)(Main);
 
 export default App;

--- a/19/components/App.js
+++ b/19/components/App.js
@@ -10,10 +10,10 @@ function mapStateToProps(state) {
   }
 }
 
-function mapDispachToProps(dispatch) {
+function mapDispatchToProps(dispatch) {
   return bindActionCreators(actionCreators, dispatch);
 }
 
-const App = connect(mapStateToProps, mapDispachToProps)(Main);
+const App = connect(mapStateToProps, mapDispatchToProps)(Main);
 
 export default App;


### PR DESCRIPTION
Corrects typo from mapDispachToProps to  mapDispatchToProps in folders 13-19.

-I love your teaching style. I'm looking forward to the next one! 