### PR TITLE
fix for warning messages regarding refs and key

### DIFF
--- a/19/components/Main.js
+++ b/19/components/Main.js
@@ -8,7 +8,7 @@ const Main = React.createClass({
         <h1>
           <Link to="/">Reduxstagram</Link>
         </h1>
-        {React.cloneElement(this.props.children, this.props)}
+        {React.cloneElement({...this.props}.children, {...this.props})}
       </div>
     )
   }


### PR DESCRIPTION
Fix to prevent refs and key being passed down, which was causing the following errors.

```
warning.js:44Warning: Main: `key` is not a prop. Trying to access it will result in `undefined` being returned. If you need to access the same value within the child component, you should pass it as a different prop. (https://fb.me/react-special-props)
```
```
warning.js:44Warning: Main: `refs` is not a prop. Trying to access it will result in `undefined` being returned. If you need to access the same value within the child component, you should pass it as a different prop. (https://fb.me/react-special-props)
```