### PR TITLE
change default state in comments reducer to be {} instead of []

### DIFF
--- a/08/reducers/comments.js
+++ b/08/reducers/comments.js
@@ -1,4 +1,4 @@
-function comments(state = [], action) {
+function comments(state = {}, action) {
   console.log(state, action);
   return state;
 }

--- a/10/reducers/comments.js
+++ b/10/reducers/comments.js
@@ -1,4 +1,4 @@
-function comments(state = [], action) {
+function comments(state = {}, action) {
   console.log(state, action);
   return state;
 }

--- a/13/reducers/comments.js
+++ b/13/reducers/comments.js
@@ -1,4 +1,4 @@
-function comments(state = [], action) {
+function comments(state = {}, action) {
   return state;
 }
 

--- a/14/reducers/comments.js
+++ b/14/reducers/comments.js
@@ -1,4 +1,4 @@
-function comments(state = [], action) {
+function comments(state = {}, action) {
   return state;
 }
 

--- a/15/reducers/comments.js
+++ b/15/reducers/comments.js
@@ -1,4 +1,4 @@
-function comments(state = [], action) {
+function comments(state = {}, action) {
   return state;
 }
 

--- a/16/reducers/comments.js
+++ b/16/reducers/comments.js
@@ -1,4 +1,4 @@
-function comments(state = [], action) {
+function comments(state = {}, action) {
   return state;
 }
 

--- a/17/reducers/comments.js
+++ b/17/reducers/comments.js
@@ -1,4 +1,4 @@
-function postComments(state = [], action) {
+function postComments(state = {}, action) {
   switch(action.type){
     case 'ADD_COMMENT':
       // return the new state with the new comment

--- a/18/reducers/comments.js
+++ b/18/reducers/comments.js
@@ -1,4 +1,4 @@
-function postComments(state = [], action) {
+function postComments(state = {}, action) {
   switch(action.type){
     case 'ADD_COMMENT':
       // return the new state with the new comment

--- a/19/reducers/comments.js
+++ b/19/reducers/comments.js
@@ -1,4 +1,4 @@
-function postComments(state = [], action) {
+function postComments(state = {}, action) {
   switch(action.type){
     case 'ADD_COMMENT':
       // return the new state with the new comment


### PR DESCRIPTION
It's not terribly important, but the comments state throughout the app is an object (not an array) so this PR makes that clearer.

I totally understand if you don't want to merge this, as it may be confusing for people seeing `state = []` in the videos, but `state = {}` in the code files.