### PR TITLE
listen 0.0.0.0 instead of localhost

### DIFF
--- a/learn-redux/devServer.js
+++ b/learn-redux/devServer.js
@@ -17,11 +17,11 @@ app.get('*', function(req, res) {
   res.sendFile(path.join(__dirname, 'index.html'));
 });
 
-app.listen(7770, 'localhost', function(err) {
+app.listen(7770, '0.0.0.0', function(err) {
   if (err) {
     console.log(err);
     return;
   }
 
-  console.log('Listening at http://localhost:7770');
+  console.log('Listening at http://0.0.0.0:7770');
 });


### PR DESCRIPTION
## Problem

Although there is no Docker requirements in the tutorial, many developers prefer to use Docker running their apps inside separated containers. 

```bash
docker run -it -v $(pwd):/var/www/learn-redux -w /var/www/learn-redux -p 7770:7770 node npm start
```

Unfortunately web server cannot be accessed while running inside Docker container.

## Solution

https://github.com/webpack/webpack-dev-server/issues/183#issuecomment-156479881