### PR TITLE
fixing typo of imported redux function

### DIFF
--- a/17/store.js
+++ b/17/store.js
@@ -1,4 +1,4 @@
-import { createStore, compse } from 'redux';
+import { createStore, compose } from 'redux';
 import { syncHistoryWithStore} from 'react-router-redux';
 import { browserHistory } from 'react-router';
 


### PR DESCRIPTION
fixing typo of destructured imported redux function:
compse   => comp**o**se