### PR TITLE
Fix mapDispatchToProps typo

### DIFF
--- a/13/components/App.js
+++ b/13/components/App.js
@@ -10,10 +10,10 @@ function mapStateToProps(state) {
   }
 }
 
-function mapDispachToProps(dispatch) {
+function mapDispatchToProps(dispatch) {
   return bindActionCreators(actionCreators, dispatch);
 }
 
-const App = connect(mapStateToProps, mapDispachToProps)(Main);
+const App = connect(mapStateToProps, mapDispatchToProps)(Main);
 
 export default App;


### PR DESCRIPTION
mapDispatchToProps was misspelled as mapDispachToProps.