### PR TITLE
Add webpack support for JSX files so that VSCode can use Emmet expanding

### DIFF
--- a/learn-redux/webpack.config.dev.js
+++ b/learn-redux/webpack.config.dev.js
@@ -20,7 +20,7 @@ module.exports = {
     loaders: [
     // js
     {
-      test: /\.js$/,
+      test: /\.jsx?$/,
       loaders: ['babel'],
       include: path.join(__dirname, 'client')
     },

--- a/learn-redux/webpack.config.prod.js
+++ b/learn-redux/webpack.config.prod.js
@@ -29,7 +29,7 @@ module.exports = {
     loaders: [
     // js
     {
-      test: /\.js$/,
+      test: /\.jsx?$/,
       loaders: ['babel'],
       include: path.join(__dirname, 'client')
     },


### PR DESCRIPTION
I added the support for JSX as a file extension in webpack. This way VSCode will allow you to use Emmet expansions while editing your JSX code.